### PR TITLE
Exposing the tuna object even if define detected + check for define.amd

### DIFF
--- a/tuna.js
+++ b/tuna.js
@@ -739,6 +739,15 @@
                 this.wet.gain.value = value;
             }
         },
+        decodedBuffer: {
+            enumerable: false,
+            get: function () {
+                return this.convolver.buffer;
+            },
+            set: function (decodedImpulse) {
+                this.convolver.buffer = decodedImpulse;
+            }
+        },
         buffer: {
             enumerable: false,
             get: function () {

--- a/tuna.js
+++ b/tuna.js
@@ -1741,11 +1741,14 @@
     Tuna.toString = Tuna.prototype.toString = function () {
         return "You are running Tuna version " + version + " by Dinahmoe!";
     };
-    if(typeof define === "function") {
+
+    // Expose Tuna to the global object
+    window.Tuna = Tuna;
+
+    // Check for amd in the define function / object
+    if(typeof define === "function" && define.amd) {
         define("Tuna", [], function () {
             return Tuna;
         });
-    } else {
-        window.Tuna = Tuna;
     }
 })(this);

--- a/tuna.js
+++ b/tuna.js
@@ -1438,7 +1438,7 @@
         sweep: {
             enumerable: true,
             get: function () {
-                return this._sweep.value;
+                return this._sweep;
             },
             set: function (value) {
                 this._sweep = Math.pow(value > 1 ? 1 : value < 0 ? 0 : value, this._sensitivity);

--- a/tuna.js
+++ b/tuna.js
@@ -182,10 +182,10 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
-        this.activateNode = userContext.createGainNode();
+        this.input = userContext.createGain();
+        this.activateNode = userContext.createGain();
         this.filter = userContext.createBiquadFilter();
-        this.output = userContext.createGainNode();
+        this.output = userContext.createGain();
 
         this.activateNode.connect(this.filter);
         this.filter.connect(this.output);
@@ -279,11 +279,11 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
-        this.activateNode = userContext.createGainNode();
+        this.input = userContext.createGain();
+        this.activateNode = userContext.createGain();
         this.convolver = this.newConvolver(properties.impulsePath || null);
-        this.makeupNode = userContext.createGainNode();
-        this.output = userContext.createGainNode();
+        this.makeupNode = userContext.createGain();
+        this.output = userContext.createGain();
 
         this.activateNode.connect(this.convolver.input);
         this.convolver.output.connect(this.makeupNode);
@@ -345,15 +345,15 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
-        this.attenuator = this.activateNode = userContext.createGainNode();
+        this.input = userContext.createGain();
+        this.attenuator = this.activateNode = userContext.createGain();
         this.splitter = userContext.createChannelSplitter(2);
         this.delayL = userContext.createDelayNode();
         this.delayR = userContext.createDelayNode();
-        this.feedbackGainNodeLR = userContext.createGainNode();
-        this.feedbackGainNodeRL = userContext.createGainNode();
+        this.feedbackGainNodeLR = userContext.createGain();
+        this.feedbackGainNodeRL = userContext.createGain();
         this.merger = userContext.createChannelMerger(2);
-        this.output = userContext.createGainNode();
+        this.output = userContext.createGain();
 
         this.lfoL = new userInstance.LFO({
             target: this.delayL.delayTime,
@@ -479,10 +479,10 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
+        this.input = userContext.createGain();
         this.compNode = this.activateNode = userContext.createDynamicsCompressor();
-        this.makeupNode = userContext.createGainNode();
-        this.output = userContext.createGainNode();
+        this.makeupNode = userContext.createGain();
+        this.output = userContext.createGain();
 
         this.compNode.connect(this.makeupNode);
         this.makeupNode.connect(this.output);
@@ -637,14 +637,14 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
-        this.activateNode = userContext.createGainNode();
+        this.input = userContext.createGain();
+        this.activateNode = userContext.createGain();
         this.convolver = userContext.createConvolver();
-        this.dry = userContext.createGainNode();
+        this.dry = userContext.createGain();
         this.filterLow = userContext.createBiquadFilter();
         this.filterHigh = userContext.createBiquadFilter();
-        this.wet = userContext.createGainNode();
-        this.output = userContext.createGainNode();
+        this.wet = userContext.createGain();
+        this.output = userContext.createGain();
 
         this.activateNode.connect(this.filterLow);
         this.activateNode.connect(this.dry);
@@ -790,14 +790,14 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
-        this.activateNode = userContext.createGainNode();
-        this.dry = userContext.createGainNode();
-        this.wet = userContext.createGainNode();
+        this.input = userContext.createGain();
+        this.activateNode = userContext.createGain();
+        this.dry = userContext.createGain();
+        this.wet = userContext.createGain();
         this.filter = userContext.createBiquadFilter();
         this.delay = userContext.createDelayNode();
-        this.feedbackNode = userContext.createGainNode();
-        this.output = userContext.createGainNode();
+        this.feedbackNode = userContext.createGain();
+        this.output = userContext.createGain();
 
         this.activateNode.connect(this.delay);
         this.activateNode.connect(this.dry);
@@ -910,12 +910,12 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
-        this.activateNode = userContext.createGainNode();
-        this.inputDrive = userContext.createGainNode();
+        this.input = userContext.createGain();
+        this.activateNode = userContext.createGain();
+        this.inputDrive = userContext.createGain();
         this.waveshaper = userContext.createWaveShaper();
-        this.outputDrive = userContext.createGainNode();
-        this.output = userContext.createGainNode();
+        this.outputDrive = userContext.createGain();
+        this.output = userContext.createGain();
 
         this.activateNode.connect(this.inputDrive);
         this.inputDrive.connect(this.waveshaper);
@@ -1073,15 +1073,15 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
+        this.input = userContext.createGain();
         this.splitter = this.activateNode = userContext.createChannelSplitter(2);
         this.filtersL = [];
         this.filtersR = [];
-        this.feedbackGainNodeL = userContext.createGainNode();
-        this.feedbackGainNodeR = userContext.createGainNode();
+        this.feedbackGainNodeL = userContext.createGain();
+        this.feedbackGainNodeR = userContext.createGain();
         this.merger = userContext.createChannelMerger(2);
-        this.filteredSignal = userContext.createGainNode();
-        this.output = userContext.createGainNode();
+        this.filteredSignal = userContext.createGain();
+        this.output = userContext.createGain();
         this.lfoL = new userInstance.LFO({
             target: this.filtersL,
             callback: this.callback
@@ -1234,8 +1234,8 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
-        this.splitter = this.activateNode = userContext.createChannelSplitter(2), this.amplitudeL = userContext.createGainNode(), this.amplitudeR = userContext.createGainNode(), this.merger = userContext.createChannelMerger(2), this.output = userContext.createGainNode();
+        this.input = userContext.createGain();
+        this.splitter = this.activateNode = userContext.createChannelSplitter(2), this.amplitudeL = userContext.createGain(), this.amplitudeR = userContext.createGain(), this.merger = userContext.createChannelMerger(2), this.output = userContext.createGain();
         this.lfoL = new userInstance.LFO({
             target: this.amplitudeL.gain,
             callback: pipe
@@ -1335,8 +1335,8 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
-        this.activateNode = userContext.createGainNode();
+        this.input = userContext.createGain();
+        this.activateNode = userContext.createGain();
         this.envelopeFollower = new userInstance.EnvelopeFollower({
             target: this,
             callback: function (context, value) {
@@ -1345,7 +1345,7 @@
         });
         this.filterBp = userContext.createBiquadFilter();
         this.filterPeaking = userContext.createBiquadFilter();
-        this.output = userContext.createGainNode();
+        this.output = userContext.createGain();
 
         //Connect AudioNodes
         this.activateNode.connect(this.filterBp);
@@ -1507,7 +1507,7 @@
         if(!properties) {
             properties = this.getDefaults();
         }
-        this.input = userContext.createGainNode();
+        this.input = userContext.createGain();
         this.jsNode = this.output = userContext.createJavaScriptNode(this.buffersize, 1, 1);
 
         this.input.connect(this.output);

--- a/tuna.js
+++ b/tuna.js
@@ -1746,13 +1746,12 @@
         return "You are running Tuna version " + version + " by Dinahmoe!";
     };
 
-    // Expose Tuna to the global object
-    window.Tuna = Tuna;
-
-    // Check for amd in the define function / object
     if(typeof define === "function" && define.amd) {
-        define("Tuna", [], function () {
+        define(function () {
             return Tuna;
         });
+    } else {
+        window.Tuna = Tuna;
     }
+
 })(this);

--- a/tuna.js
+++ b/tuna.js
@@ -190,7 +190,7 @@
         this.Q = properties.resonance || this.defaults.Q.value;
         this.filterType = properties.filterType || this.defaults.filterType.value;
         this.gain = properties.gain || this.defaults.gain.value;
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Filter.prototype = Object.create(Super, {
         name: {
@@ -286,7 +286,7 @@
         this.makeupNode.connect(this.output);
 
         this.makeupGain = properties.makeupGain || this.defaults.makeupGain;
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Cabinet.prototype = Object.create(Super, {
         name: {
@@ -372,7 +372,7 @@
         this.attenuator.gain.value = 0.6934; // 1 / (10 ^ (((20 * log10(3)) / 3) / 20))
         this.lfoL.activate(true);
         this.lfoR.activate(true);
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Chorus.prototype = Object.create(Super, {
         name: {
@@ -481,7 +481,7 @@
         this.attack = properties.attack || this.defaults.attack.value;
         this.ratio = properties.ratio || this.defaults.ratio.value;
         this.knee = properties.knee || this.defaults.knee.value;
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Compressor.prototype = Object.create(Super, {
         name: {
@@ -649,7 +649,7 @@
         this.level = properties.level || this.defaults.level.value;
         this.filterHigh.type = 0;
         this.filterLow.type = 1;
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Convolver.prototype = Object.create(Super, {
         name: {
@@ -792,7 +792,7 @@
         this.dryLevel = properties.dryLevel || this.defaults.dryLevel.value;
         this.cutoff = properties.cutoff || this.defaults.cutoff.value;
         this.filter.type = 0;
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Delay.prototype = Object.create(Super, {
         name: {
@@ -905,7 +905,7 @@
         this.outputGain = properties.outputGain || this.defaults.outputGain.value;
         this.curveAmount = properties.curveAmount || this.defaults.curveAmount.value;
         this.algorithmIndex = properties.algorithmIndex || this.defaults.algorithmIndex.value;
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Overdrive.prototype = Object.create(Super, {
         name: {
@@ -1098,7 +1098,7 @@
 
         this.lfoL.activate(true);
         this.lfoR.activate(true);
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Phaser.prototype = Object.create(Super, {
         name: {
@@ -1240,7 +1240,7 @@
 
         this.lfoL.activate(true);
         this.lfoR.activate(true);
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Tremolo.prototype = Object.create(Super, {
         name: {
@@ -1341,7 +1341,7 @@
 
         this.activateNode.gain.value = 2;
         this.envelopeFollower.activate(true);
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.WahWah.prototype = Object.create(Super, {
         name: {
@@ -1631,7 +1631,7 @@
         this.target = properties.target || {};
         this.output.onaudioprocess = this.callback(properties.callback ||
         function () {});
-        this.bypass = false;
+        this.bypass = properties.bypass || false;
     };
     Tuna.prototype.LFO.prototype = Object.create(Super, {
         name: {

--- a/tuna.js
+++ b/tuna.js
@@ -1508,7 +1508,7 @@
             properties = this.getDefaults();
         }
         this.input = userContext.createGain();
-        this.jsNode = this.output = userContext.createJavaScriptNode(this.buffersize, 1, 1);
+        this.jsNode = this.output = userContext.createScriptProcessor(this.buffersize, 1, 1);
 
         this.input.connect(this.output);
 
@@ -1642,7 +1642,7 @@
     });
     Tuna.prototype.LFO = function (properties) {
         //Instantiate AudioNode
-        this.output = userContext.createJavaScriptNode(256, 1, 1);
+        this.output = userContext.createScriptProcessor(256, 1, 1);
         this.activateNode = userContext.destination;
 
         //Set Properties

--- a/tuna.js
+++ b/tuna.js
@@ -281,7 +281,7 @@
         }
         this.input = userContext.createGainNode();
         this.activateNode = userContext.createGainNode();
-        this.convolver = this.newConvolver(properties.impulsePath || "../impulses/impulse_guitar.wav");
+        this.convolver = this.newConvolver(properties.impulsePath || null);
         this.makeupNode = userContext.createGainNode();
         this.output = userContext.createGainNode();
 
@@ -320,6 +320,15 @@
             },
             set: function (value) {
                 this.makeupNode.gain.value = value;
+            }
+        },
+        decodedBuffer: {
+            enumerable: false,
+            get: function () {
+                return this.convolver.buffer;
+            },
+            set: function (decodedImpulse) {
+                this.convolver.buffer = decodedImpulse;
             }
         },
         newConvolver: {

--- a/tuna.js
+++ b/tuna.js
@@ -348,8 +348,8 @@
         this.input = userContext.createGain();
         this.attenuator = this.activateNode = userContext.createGain();
         this.splitter = userContext.createChannelSplitter(2);
-        this.delayL = userContext.createDelayNode();
-        this.delayR = userContext.createDelayNode();
+        this.delayL = userContext.createDelay();
+        this.delayR = userContext.createDelay();
         this.feedbackGainNodeLR = userContext.createGain();
         this.feedbackGainNodeRL = userContext.createGain();
         this.merger = userContext.createChannelMerger(2);
@@ -795,7 +795,7 @@
         this.dry = userContext.createGain();
         this.wet = userContext.createGain();
         this.filter = userContext.createBiquadFilter();
-        this.delay = userContext.createDelayNode();
+        this.delay = userContext.createDelay();
         this.feedbackNode = userContext.createGain();
         this.output = userContext.createGain();
 

--- a/tuna.js
+++ b/tuna.js
@@ -328,7 +328,7 @@
                 return this.convolver.buffer;
             },
             set: function (decodedImpulse) {
-                this.convolver.buffer = decodedImpulse;
+                this.convolver.decodedBuffer = decodedImpulse;
             }
         },
         newConvolver: {

--- a/tuna.js
+++ b/tuna.js
@@ -648,7 +648,7 @@
         this.dryLevel = properties.dryLevel || this.defaults.dryLevel.value;
         this.wetLevel = properties.wetLevel || this.defaults.wetLevel.value;
         this.highCut = properties.highCut || this.defaults.highCut.value;
-        this.buffer = properties.impulse || "../impulses/ir_rev_short.wav";
+        this.buffer = properties.impulse || null;
         this.lowCut = properties.lowCut || this.defaults.lowCut.value;
         this.level = properties.level || this.defaults.level.value;
         this.filterHigh.type = 0;

--- a/tuna.js
+++ b/tuna.js
@@ -660,8 +660,8 @@
         this.buffer = properties.impulse || null;
         this.lowCut = properties.lowCut || this.defaults.lowCut.value;
         this.level = properties.level || this.defaults.level.value;
-        this.filterHigh.type = 0;
-        this.filterLow.type = 1;
+        this.filterHigh.type = "lowpass";
+        this.filterLow.type = "highpass";
         this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Convolver.prototype = Object.create(Super, {
@@ -813,7 +813,7 @@
         this.wetLevel = properties.wetLevel || this.defaults.wetLevel.value;
         this.dryLevel = properties.dryLevel || this.defaults.dryLevel.value;
         this.cutoff = properties.cutoff || this.defaults.cutoff.value;
-        this.filter.type = 0;
+        this.filter.type = "lowpass";
         this.bypass = properties.bypass || false;
     };
     Tuna.prototype.Delay.prototype = Object.create(Super, {
@@ -1095,8 +1095,8 @@
         while(i--) {
             this.filtersL[i] = userContext.createBiquadFilter();
             this.filtersR[i] = userContext.createBiquadFilter();
-            this.filtersL[i].type = 7;
-            this.filtersR[i].type = 7;
+            this.filtersL[i].type = "allpass";
+            this.filtersR[i].type = "allpass";
         }
         this.input.connect(this.splitter);
         this.input.connect(this.output);
@@ -1492,8 +1492,8 @@
         init: {
             value: function () {
                 this.output.gain.value = 1;
-                this.filterPeaking.type = 5;
-                this.filterBp.type = 2;
+                this.filterPeaking.type = "peaking";
+                this.filterBp.type = "bandpass";
                 this.filterPeaking.frequency.value = 100;
                 this.filterPeaking.gain.value = 20;
                 this.filterPeaking.Q.value = 5;


### PR DESCRIPTION
Even if a project uses require.js or another amd loader (and, so, define is a function in the code), it doesn't mean it wants to load *every* library using amd. Maybe one wants to use amd only to load certain plugins and load static libraries with the old script-in-the-head method.

Since these mixed-approach web application exist (namely, [my current KievII Host angularjs branch](https://github.com/janesconference/KievIIHost/tree/feature/angular) does this : ), I propose to always expose the Tuna object and return the module only if define is present and a function (checking define.amd in the process, since define is quite a generic function name). This is what jQuery does, anyway.