### PR TITLE
use AudioContext instead of webkitAudioContext

### DIFF
--- a/tuna.js
+++ b/tuna.js
@@ -17,9 +17,13 @@
 //Originally written by Alessandro Saccoia, Chris Coniglio and Oskar Eriksson
 (function (window) {
     var userContext, userInstance, Tuna = function (context) {
+            if (! window.AudioContext) {
+		window.AudioContext = window.webkitAudioContext;
+   	    }
+
             if(!context) {
                 console.log("tuna.js: Missing audio context! Creating a new context for you.");
-                context = window.webkitAudioContext && (new window.webkitAudioContext());
+                context = window.AudioContext && (new window.AudioContext());
             }
             userContext = context;
             userInstance = this;


### PR DESCRIPTION
I've aliased AudioContext to webkitAudioContext where that is defined. The Web Audio spec drops the vendor prefix, so this should mean Tuna will work on other implementations (Firefox is on its way!)

Cheers, 

Chris 
