### PR TITLE
Removed duplicate bypass option in README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ var filter = new tuna.Filter({
                  frequency: 20,         //20 to 22050
                  Q: 1,                  //0.001 to 100
                  gain: 0,               //-40 to 40
-                 bypass: 1,             //0 to 1+
                  filterType: 0,         //0 to 7, corresponds to the filter types in the native filter node: lowpass, highpass, bandpass, lowshelf, highshelf, peaking, notch, allpass in that order
                  bypass: 0
              });


### PR DESCRIPTION
The filter example had "bypass" twice.
