### PR TITLE
Corrected connectify shim

### DIFF
--- a/tuna.js
+++ b/tuna.js
@@ -148,14 +148,20 @@
         userInstance = this;
     }
     function connectify (context) {
+        if(context.__connectified__ === true) return;
+        
         var gain = context.createGain(),
             proto = Object.getPrototypeOf(Object.getPrototypeOf(gain)),
             oconnect = proto.connect;
 
         proto.connect = shimConnect;
+        context.__connectified__ = true;  // Prevent overriding connect more than once
 
-        function shimConnect (node) {
-            oconnect.call(this, Super.isPrototypeOf(node) ? node.input : node);
+        function shimConnect () {
+            var node = Array.prototype.shift.apply(arguments);
+            node = Super.isPrototypeOf ? (Super.isPrototypeOf(node) ? node.input : node) : (node.input || node);
+            Array.prototype.unshift.apply(arguments, node);
+            oconnect.apply(this, arguments);
             return node;
         }
     }


### PR DESCRIPTION
The shim drops the additional arguments which can be passed to connect.  The official connect method signature includes output and input numbers as well as the node to connect to.  Using in it's current state causes all audio to come out of the left channel when using certain effects.

This update also addresses the issue of creating multiple Tuna instances in a session.  The previous connectify call would create a chain of shims, adding one each time new Tuna(...) is called.

Also, when using chrome, the Super.isPrototypeOf call does not exist.