### PR TITLE
Require Missing Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
   "homepage": "https://github.com/Dinahmoe/tuna#readme",
   "devDependencies": {
     "uglify": "^0.1.5"
+  },
+  "dependencies": {
+    "net": "^1.0.2",
+    "tls": "0.0.1"
   }
 }


### PR DESCRIPTION
`tls` and `net` were both missing from Tuna, causing webpack to error out on me. This fixes it.

Thanks