### PR TITLE
Makes fallback context creation work in bundled scripts

### DIFF
--- a/tuna.js
+++ b/tuna.js
@@ -133,14 +133,14 @@
             return new Tuna(context);
         }
 
-        var window = window || {};
+        var _window = typeof window === 'undefined' ? {} : window;
 
-        if (!window.AudioContext) {
-            window.AudioContext = window.webkitAudioContext;
+        if (!_window.AudioContext) {
+            _window.AudioContext = _window.webkitAudioContext;
         }
         if (!context) {
             console.log("tuna.js: Missing audio context! Creating a new context for you.");
-            context = window.AudioContext && (new window.AudioContext());
+            context = _window.AudioContext && (new _window.AudioContext());
         }
         if (!context) {
             throw new Error("Tuna cannot initialize because this environment does not support web audio.");

--- a/tuna.js
+++ b/tuna.js
@@ -132,6 +132,9 @@
         if (!(this instanceof Tuna)) {
             return new Tuna(context);
         }
+
+        var window = window || {};
+
         if (!window.AudioContext) {
             window.AudioContext = window.webkitAudioContext;
         }

--- a/tuna.js
+++ b/tuna.js
@@ -14,7 +14,7 @@
     OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 /*global module*/
-(function(window) {
+(function() {
 
     var userContext,
         userInstance,
@@ -2098,4 +2098,4 @@
     Tuna.toString = Tuna.prototype.toString = function() {
         return "Please visit https://github.com/Theodeus/tuna/wiki for instructions on how to use Tuna.js";
     };
-})(this);
+})();


### PR DESCRIPTION
Basically this removes the top-level `window` argument and does a check in the `Tuna()` constructor instead.

If it's being run in node or in a bundle, the statements assigning `Tuna` to the `window` object should never be reached.

The constructor function already deals nicely with checking for `AudioContext` support. I only had to create a `_window` variable to keep the custom informative error when doing `new Tuna()` in a node environment.

I tested this in a Webpack bundled app, in the Node REPL and on a very basic HTML page.