### PR TITLE
Adds note on Panner and polyfilling to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Effect list:
     <li>Bitcrusher</li>
     <li>Moog Filter</li>
     <li>Ping Pong Delay</li>
-    <li>Panner</li>
+    <li>Panner (needs polyfilling, see Panner section [in the wiki](https://github.com/Theodeus/tuna/wiki))</li>
     <li>Gain</li>
 </ul>
 


### PR DESCRIPTION
I just realised that `StereoPannerNode`, used in `tuna.Panner`, is not supported by IE and Safari. It needs polyfilling, so I added a note on that to the README.

I also updated the wiki with info on this.